### PR TITLE
Require SwaggerBake config to be defined here

### DIFF
--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -101,7 +101,7 @@ class Configuration
     public function __construct(array $config = [], string $root = ROOT)
     {
         $this->root = $root;
-        $config = !empty($config) ? $config : Configure::read('SwaggerBake');
+        $config = !empty($config) ? $config : Configure::readOrFail('SwaggerBake');
 
         foreach (['yml', 'json', 'webPath', 'prefix'] as $property) {
             if (!array_key_exists(key: $property, array: $config)) {


### PR DESCRIPTION
As the `Configure::read()` call is the last-ditch effort to get config for the Configuration instance, if the config is not readable at this point the object construction should fail.